### PR TITLE
Removing reserved words char and interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,16 +26,16 @@
   // observer to work with.
   Observer.tokenize = function(keypath, interfaces, root) {
     tokens = []
-    current = {interface: root, path: ''}
+    current = {interf: root, path: ''}
 
     for (index = 0; index < keypath.length; index++) {
-      char = keypath.charAt(index)
+      chr = keypath.charAt(index)
 
-      if(!!~interfaces.indexOf(char)) {
+      if(!!~interfaces.indexOf(chr)) {
         tokens.push(current)
-        current = {interface: char, path: ''}
+        current = {interf: chr, path: ''}
       } else {
-        current.path += char
+        current.path += chr
       }
     }
 
@@ -85,7 +85,7 @@
           this.set(true, token, current, this.update.bind(this))
           this.objectPath[index] = current
         }
-        
+
         current = this.get(token, current)
       } else {
         if(unreached === false) unreached = index
@@ -152,9 +152,9 @@
   Observer.prototype.interfaces = function() {
     interfaces = Object.keys(this.options.adapters)
 
-    Object.keys(sightglass.adapters).forEach(function(interface) {
-      if(!~interfaces.indexOf(interface)) {
-        interfaces.push(interface)
+    Object.keys(sightglass.adapters).forEach(function(interf) {
+      if(!~interfaces.indexOf(interf)) {
+        interfaces.push(interf)
       }
     })
 
@@ -163,8 +163,8 @@
 
   // Convenience function to grab the adapter for a specific key.
   Observer.prototype.adapter = function(key) {
-    return this.options.adapters[key.interface] ||
-      sightglass.adapters[key.interface]
+    return this.options.adapters[key.interf] ||
+      sightglass.adapters[key.interf]
   }
 
   // Unobserves the entire keypath.


### PR DESCRIPTION
Just like in Rivets (https://github.com/mikeric/rivets/pull/377), in Sightglass there are [reserved words](http://www.w3schools.com/js/js_reserved.asp) as keys and variable names. 

```
[Thu Sep 18 09:36:16 root@zoltandev:~/sightglass]$ '/usr/bin/java' '-jar' /var/www/lighttpd/app/Resources/java/yuicompressor-2.4.7.jar '--charset' 'UTF-8' '-o' '/tmp/rivets' '--type' 'js' 'index.js'

[ERROR] 29:25:invalid property id

[ERROR] 31:19:missing ) in parenthetical

[ERROR] 31:52:missing ; before statement

[ERROR] 32:13:syntax error

[ERROR] 34:36:identifier is a reserved word

[ERROR] 35:16:syntax error

[ERROR] 36:18:syntax error

[ERROR] 37:13:syntax error

[ERROR] 38:17:syntax error

[ERROR] 48:11:missing ) in parenthetical

[ERROR] 48:12:syntax error

[ERROR] 49:17:syntax error

[ERROR] 51:28:missing ; before statement

[ERROR] 53:5:syntax error

[ERROR] 55:48:missing ; before statement

[ERROR] 56:13:syntax error

[ERROR] 57:13:syntax error

[ERROR] 58:11:syntax error

[ERROR] 59:80:missing ; before statement

[ERROR] 61:7:syntax error

[ERROR] 63:13:syntax error

[ERROR] 68:3:syntax error

[ERROR] 72:12:syntax error

[ERROR] 73:14:syntax error

[ERROR] 74:16:syntax error

[ERROR] 76:10:syntax error

[ERROR] 77:42:missing ; before statement

[ERROR] 78:59:missing ; before statement

[ERROR] 79:59:missing ; before statement

[ERROR] 80:18:syntax error

[ERROR] 81:18:syntax error

[ERROR] 82:18:syntax error

[ERROR] 84:9:syntax error

[ERROR] 85:16:syntax error

[ERROR] 86:16:syntax error

[ERROR] 90:7:syntax error

[ERROR] 91:42:missing ; before statement

[ERROR] 93:43:missing ; before statement

[ERROR] 94:16:syntax error

[ERROR] 96:7:syntax error

[ERROR] 97:6:syntax error

[ERROR] 99:29:missing ; before statement

[ERROR] 100:12:syntax error

[ERROR] 103:11:invalid return

[ERROR] 104:3:syntax error

[ERROR] 107:12:syntax error

[ERROR] 108:49:missing ; before statement

[ERROR] 109:46:missing ; before statement

[ERROR] 110:14:syntax error

[ERROR] 121:5:syntax error

[ERROR] 155:64:missing formal parameter

[ERROR] 156:40:identifier is a reserved word

[ERROR] 157:20:syntax error

[ERROR] 159:6:missing ; before statement

[ERROR] 162:3:syntax error

[ERROR] 165:12:syntax error

[ERROR] 166:47:missing name after . operator

[ERROR] 167:18:syntax error

[ERROR] 194:1:syntax error

[ERROR] 1:0:Compilation produced 59 syntax errors.
```

I changed these. I ran Rivets tests with the changed file:

```
[Thu Sep 18 10:56:45 root@zoltandev:~/rivets]$ cp ../sightglass/index.js node_modules/sightglass/
cp: overwrite `node_modules/sightglass/index.js'? y
[Thu Sep 18 10:57:14 root@zoltandev:~/rivets]$ gulp build
[10:57:23] Using gulpfile ~/rivets/gulpfile.js
[10:57:23] Starting 'build'...
[10:57:23] Finished 'build' after 26 ms
[Thu Sep 18 10:57:27 root@zoltandev:~/rivets]$
[Thu Sep 18 10:57:30 root@zoltandev:~/rivets]$ gulp spec
[10:57:40] Using gulpfile ~/rivets/gulpfile.js
[10:57:40] Starting 'spec'...
[10:57:40] Finished 'spec' after 25 ms

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  78 passing (343ms)

[Thu Sep 18 10:57:41 root@zoltandev:~/rivets]$
```
