### PR TITLE
Add ';'  to the end of index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,4 +200,4 @@
   } else {
     this.sightglass = sightglass
   }
-}).call(this)
+}).call(this);


### PR DESCRIPTION
Allows other files to be concatenated to sightglass. This breaks for Chrome because not having the semicolon makes Chrome throw a TypeError. Test case: http://jsfiddle.net/nd9hzxr1/1/

Found by @steffansluis
