### PR TITLE
Don't use .bind(this) on update callback. This creates each time a new f...

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
     this.callback = callback
     this.objectPath = []
     this.parse()
+    var self = this
 
     if (isObject(this.target = this.realize())) {
       this.set(true, this.key, this.target, this.callback)
@@ -80,12 +81,12 @@
       if (isObject(current)) {
         if (typeof this.objectPath[index] !== 'undefined') {
           if (current !== (prev = this.objectPath[index])) {
-            this.set(false, token, prev, this.update.bind(this))
-            this.set(true, token, current, this.update.bind(this))
+            this.set(false, token, prev, this.update)
+            this.set(true, token, current, this.update)
             this.objectPath[index] = current
           }
         } else {
-          this.set(true, token, current, this.update.bind(this))
+          this.set(true, token, current, this.update)
           this.objectPath[index] = current
         }
 
@@ -96,7 +97,7 @@
         }
 
         if (prev = this.objectPath[index]) {
-          this.set(false, token, prev, this.update.bind(this))
+          this.set(false, token, prev, this.update)
         }
       }
     }, this)
@@ -112,19 +113,19 @@
   Observer.prototype.update = function() {
     var next, oldValue
 
-    if ((next = this.realize()) !== this.target) {
-      if (isObject(this.target)) {
-        this.set(false, this.key, this.target, this.callback)
+    if ((next = self.realize()) !== self.target) {
+      if (isObject(self.target)) {
+        self.set(false, self.key, self.target, self.callback)
       }
 
       if (isObject(next)) {
-        this.set(true, this.key, next, this.callback)
+        self.set(true, self.key, next, self.callback)
       }
 
-      oldValue = this.value()
-      this.target = next
+      oldValue = self.value()
+      self.target = next
 
-      if (this.value() !== oldValue) this.callback()
+      if (self.value() !== oldValue) self.callback()
     }
   }
 
@@ -180,7 +181,7 @@
 
     this.tokens.forEach(function(token, index) {
       if (obj = this.objectPath[index]) {
-        this.set(false, token, obj, this.update.bind(this))
+        this.set(false, token, obj, this.update)
       }
     }, this)
 


### PR DESCRIPTION
...unction wich will result in memory leak in adapters.

It will correct issue #10 .
Now the adapter will receive the same callback on observe and unobserve. The weakmap will be correctly cleaned up and we will have no more memory leak ;)

My correction won't use the bind function as it is not available in all browsers. The good old "var self = this" is not as elegant but it will work fine.