### PR TITLE
Prevent memory leaks in rivets adapters fix #10

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@
     this.objectPath = []
     this.parse()
 
+    this.updateCallback = this.update.bind(this)
+
     if (isObject(this.target = this.realize())) {
       this.set(true, this.key, this.target, this.callback)
     }
@@ -80,12 +82,12 @@
       if (isObject(current)) {
         if (typeof this.objectPath[index] !== 'undefined') {
           if (current !== (prev = this.objectPath[index])) {
-            this.set(false, token, prev, this.update.bind(this))
-            this.set(true, token, current, this.update.bind(this))
+            this.set(false, token, prev, this.updateCallback)
+            this.set(true, token, current, this.updateCallback)
             this.objectPath[index] = current
           }
         } else {
-          this.set(true, token, current, this.update.bind(this))
+          this.set(true, token, current, this.updateCallback)
           this.objectPath[index] = current
         }
 
@@ -96,7 +98,7 @@
         }
 
         if (prev = this.objectPath[index]) {
-          this.set(false, token, prev, this.update.bind(this))
+          this.set(false, token, prev, this.updateCallback)
         }
       }
     }, this)
@@ -180,7 +182,7 @@
 
     this.tokens.forEach(function(token, index) {
       if (obj = this.objectPath[index]) {
-        this.set(false, token, obj, this.update.bind(this))
+        this.set(false, token, obj, this.updateCallback)
       }
     }, this)
 


### PR DESCRIPTION
Using `.bind(this)` on `Observer#update()` create a new function instance each time: thereby, adapters can’t unobserve sightglass update callback.

The solution is to keep an reference to the *binded* update method. 

A pull request (#11) has allready been proposed by @jccazeaux, but:

- @jccazeaux ’s PR do not work at all: `var self` is unproperly  initialised in the constructor, not in the methods that use it.   And... anyway, even with `self` properly initialised, using  `self.update` remains a mistake (self.update remain a function, not  an instance method)
- Maybe its ok to use `.bind()` instead of `var self`, because  [browsers support](http://kangax.github.io/compat-table/es5/#Function.prototype.bind) is large enough (and polyfilling bind() is easy)

Fix #10 and https://github.com/mikeric/rivets/issues/430