### PR TITLE
Store bound update method in constructor and use it as callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@
     this.keypath = keypath
     this.callback = callback
     this.objectPath = []
+    this.update = this.update.bind(this)
     this.parse()
 
     if (isObject(this.target = this.realize())) {
@@ -80,12 +81,12 @@
       if (isObject(current)) {
         if (typeof this.objectPath[index] !== 'undefined') {
           if (current !== (prev = this.objectPath[index])) {
-            this.set(false, token, prev, this.update.bind(this))
-            this.set(true, token, current, this.update.bind(this))
+            this.set(false, token, prev, this.update)
+            this.set(true, token, current, this.update)
             this.objectPath[index] = current
           }
         } else {
-          this.set(true, token, current, this.update.bind(this))
+          this.set(true, token, current, this.update)
           this.objectPath[index] = current
         }
 
@@ -96,7 +97,7 @@
         }
 
         if (prev = this.objectPath[index]) {
-          this.set(false, token, prev, this.update.bind(this))
+          this.set(false, token, prev, this.update)
         }
       }
     }, this)
@@ -180,7 +181,7 @@
 
     this.tokens.forEach(function(token, index) {
       if (obj = this.objectPath[index]) {
-        this.set(false, token, obj, this.update.bind(this))
+        this.set(false, token, obj, this.update)
       }
     }, this)
 


### PR DESCRIPTION
Currently each time update method is used as callback, it pass a new / different bound instance
The callback is not removed when `unobserve` is called and each time the same object is bound to a rivets view the callback count increases.

Another side effect is the memory leak, independent of the object be rebound to a view, because observer instance cannot be collected so the binding and the HTMLElement.

The issue can be see in examples as simple as http://s.codepen.io/blikblum/debug/BjYPgo
Just break at `rivets.adapter['.'].unobserve`, click in bind / unbind and see 'person' callbacks increase


